### PR TITLE
Initial water-in-oil protocol from Google docs

### DIFF
--- a/txtl-liposome_water-in-oil.md
+++ b/txtl-liposome_water-in-oil.md
@@ -192,7 +192,7 @@ interface to stabilize and flatten between the emulsion and buffer
 3. Wait 5 minutes before imaging (since the liposomes will float
    everywhere and can be tricky to catch them).
 
-4. Observe on microscope. [Sample images] of what you should see:
+4. Observe on an inverted microscope. [Sample images] of what you should see:
 
 ### Alternative method (neha): 
 

--- a/txtl-liposome_water-in-oil.md
+++ b/txtl-liposome_water-in-oil.md
@@ -1,0 +1,217 @@
+# TX-TL Liposome Using Water-in-Oil Emulsion
+
+Version 0.1.0, 8 August 2018
+
+Contributors:
+Aaron Engelhart (University of Minnesota),
+Jan Gregrowicz (Caltech),
+Joseph Heili (University of Minnesota),
+Zoila Jurado (Caltech),
+Neha Kama (Northwestern),
+Akshay Maheshwari (Stanford),
+Richard Murray (Caltech),
+Milena Popovic (Blue Marble Space),
+Kazhito Tabata (University of Tokyo),
+Paola Torre (University of Pennsylvania).
+
+## Overview and Materials
+
+This protocol describes how to create liposomes that contain TX-TL
+inside of a lipid-based container. The liposomes created by these
+protocols are between 1 and 10 um in diameter and should be usable
+with an cell-free protein expression system.
+
+The preparation of liposomes using w/o emulsions as template requires
+four steps:
+
+### **Step 0**: Deposition of a thin lipid film in a glass vial
+
+#### Materials:
+
+* Glass vials (any will do, but we use [2mL Fisherbrand Class B Clear
+  Glass Threaded vials: cat #:
+  03-339-21A](https://www.fishersci.com/shop/products/fisherbrand-class-b-clear-glass-threaded-vials-with-closures-packaged-separately-12/p-204738](https://www.fishersci.com/shop/products/fisherbrand-class-b-clear-glass-threaded-vials-with-closures-packaged-separately-12/p-204738)
+
+* POPC in chloroform: [https://avantilipids.com/product/850457](https://avantilipids.com/product/850457) 
+
+* Lyss-Rhod-PE:
+  [https://avantilipids.com/product/810150](https://avantilipids.com/product/810150)
+
+* Cholesterol in chloroform (25 mg/ml): https://avantilipids.com/product/700000
+
+* Glass syringes of various sizes (10 uL, 50 uL, 250 uL, and 1 mL are
+  suggested ex. Hamilton gastight cat #: 14-815-238, but any will do)
+  for use with lipids and chloroform
+  [https://www.hamiltoncompany.com/products/syringes-and-needles/general-syringes/gastight-syringes](https://www.hamiltoncompany.com/products/syringes-and-needles/general-syringes/gastight-syringes)
+
+### **Step 1**: Preparation of the oil containing lipids
+
+#### Materials:
+
+* Mineral oil: [https://us.vwr.com/store/product/7422728/mineral-oil-light-white-high-purity-grade](https://us.vwr.com/store/product/7422728/mineral-oil-light-white-high-purity-grade)
+
+### **Step 2**: Self-assembly of the Liposomes by centrifugation
+
+#### Materials:
+
+* 20 uM of HPTS stock solution: ([https://www.thermofisher.com/order/catalog/product/H348](https://www.thermofisher.com/order/catalog/product/H348))
+
+* 100 mM HEPES, 200 mM glucose pH 8
+
+* 2M Sucrose Stock
+
+* 100 mM HEPES + 250 mM glucose, pH 8
+
+* 100 mM HEPES, 200 mM sucrose pH 8
+
+### **Step 3**: Microscopy Visualization
+
+#### Materials:
+
+* Frame Seals: [https://www.thermofisher.com/order/catalog/product/S24736](https://www.thermofisher.com/order/catalog/product/S24736)
+
+* Glass slides
+
+## Step 0: Deposition of a thin lipid film in a glass vials
+
+The first step in the protocol is to generate the lipid film required
+to to form the lipid-in-mineral oil solution. Makes 6 samples with
+accurate measurement. Each vial will have ~ 15 mg of lipid with 0.1
+mol % of 18:1 Lyss-Rho-PE.
+
+1. Create lipid master mix in a glass beaker 
+
+    a. POPC/Lyss-Rhod-PE 
+
+        i. Add  4 mL (100 mg) of POPC in chloroform (25 mg/ml) 
+
+        ii. Add 200 uL (0.2 mg) of Lyss-Rho-PE in chloroform (1 mg/mL) 
+
+        iii. Swirl gently until all POPC is dissolved and color is homogeneous.
+
+    b. POPC/Cholesterol/Lyss-Rhod-PE 
+
+        i. Add 2.668 mL (66.7 mg) of POPC in chloroform (25 mg/ml) 
+
+        ii. Add 1.332 mL (33.3 mg) of Cholesterol in chloroform (25 mg/ml) 
+
+        iii. Add 200 uL (0.2 mg) of Lyss-Rho-PE in chloroform (1 mg/mL) 
+
+        iv. Swirl gently until all POPC is dissolved and color is homogeneous.
+
+2. Aliquot 700 uL of POPC/Cholesterol/Lyss-Rhod-PE Chloroform solution
+into 2 mL glass vials (6 vials total)
+
+3. Place uncapped vials in fume hood, loosely covered with aluminum
+foil and allow to evacuate overnight in fume hood (~6-8 hours).
+
+    * **Note:** The purpose of the aluminum foil cover is to protect
+      particles from contaminating the POPC/Cholesterol/Lyss-Rhod-PE
+      as it evaporates.
+
+4. Move vials to vacuum chamber and vacuum for an additional 2 hours..
+
+5. Store in -20 degC.
+
+**Note:** Remaining POPC in chloroform, cholesterol, and  Lyss-Rho-PE in chloroform can be stored at -20 degC in the glass vial with PTFE caps and sealed parafilm.
+
+## Step 1: Preparation of the oil containing lipids
+
+1. Mix mineral oil by gentle inversion before use 
+
+2. Place 0.5 mL of mineral oil into each of the vials.
+
+3. Incubate at 60 degC  for 10 min
+
+4. Vortex for 10 mins
+
+5. Incubate vials for 3 hrs at 60 degC.
+
+6. Wrap up the top of the vials with aluminum foil and seal with parafilm.
+
+7. Sonicate in an heated water bath for 30 minutes,at 60 degC .
+
+    a. **Note:** If a sonicator is unavailable then repeat 60 degC
+    incubation and vortexing until the lipid is completely dissolved.
+
+## Step 2: Self-assembly of the Liposomes by centrifugation
+
+1. Place 225 μL of centrifuge buffer (100 mM HEPES + 200 mM glucose,
+   pH 8) into a labeled eppendorf tube.
+
+    a. **Note**: When IVTL systems are used, the outer solution should
+    also contain the small molecular weight components of the IVTL
+    system.
+
+2. Add in 30 uL of inner solution (100 mM HEPES, 200 mM sucrose pH 8,
+   and, if needed, 2 uM of a water-soluble fluorescent dye like HPTS
+   or calcein.) to 500 uL of suspended lipid in oil from Step
+   1. Vortex for 30 s. Equilibrate for 10 min at 4 degC.
+
+    * **Note**: When IVTL systems are used, buffer is omitted. IVTLs
+    come with their own buffers.
+
+3. Add the emulsion on top of the 225 μL centrifuge buffer by
+pipetting against the wall of the tube, wait at least 1 minute for the
+interface to stabilize and flatten between the emulsion and buffer
+
+4. Centrifuge at 18000 rcf at 4 degC  for 15 min  
+
+    * **Note:** If the top phase (oil) is clear, that suggests that
+      droplets have passed into the bottom buffer, becoming vesicles.
+
+5. Carefully remove as much mineral oil as possible with a
+   gel-loading-pipette-tip from the top.
+
+    * **Note: **The goal is to remove as much oil up to the interface
+    without disturbing the buffer below.
+
+6. Place 225 μL of wash buffer (100 mM HEPES + 250 mM glucose, pH 8)
+   into a labeled eppendorf tube.
+
+7. Add the centrifuge buffer (where the vesicles should have formed)
+   to eppendorf tubes with wash buffer. Make sure to use a new tip to
+   avoid contamination.
+
+    * **Note:** An alternative method is to open the eppendorf tube
+    and use a 21-gauge needle to punch a hole at the bottom of the
+    eppendorf tube. Remove the needle and the close the lid to allow
+    the buffer solution to drip out.
+
+8. Centrifuge at 12000 rcf at 4 degC  for 5 min
+
+9. Transfer 225uL from the bottom of the eppendorf tubes with wash
+   buffer into a new labeled eppendorf tube.
+
+10. Add 10 μL of solution to 10 μL of final buffer (50 mM HEPES + 300
+    mM glucose, pH 8), careful not to touch the sides of tube If the
+    bottom buffer is already HEPES, then there is no need for buffer
+    change.  Is there an obvious reason to not directly go into the
+    desired buffer?
+
+## Step 3: Microscopy Visualization
+
+1. Use Frameseal or Spacer (20 mm D x 0.12 mm depth) to make a small
+   chamber on a microscope slide.
+
+2. Add 10 μL of the final solution to the chamber and seal with cover slip
+
+3. Wait 5 minutes before imaging (since the liposomes will float
+   everywhere and can be tricky to catch them).
+
+4. Observe on microscope. [Sample images] of what you should see:
+
+### Alternative method (neha): 
+
+* Use a glass bottom chamber:
+  [https://www.thermofisher.com/order/catalog/product/154453](https://www.thermofisher.com/order/catalog/product/154453)
+
+* Block glass by adding 0.5 mL of a 1mg/mL BSA in PBS solution for 10
+  minutes (alternatively block by adding 0.5 mL o[f
+  SuperBlock](https://www.thermofisher.com/order/catalog/product/37515)
+  for 5 min). The blocking step is important because phospholipid
+  vesicles will rupture to some degree on glass.
+
+* Rinse with PBS 3X. Add 0.5 mL of final buffer from above to
+  chamber. Add 10 uL of vesicle sample to chamber, let settle over a
+  few minutes. Image on scope with green and red channels.

--- a/txtl-liposome_water-in-oil.md
+++ b/txtl-liposome_water-in-oil.md
@@ -11,6 +11,7 @@ Neha Kama (Northwestern),
 Akshay Maheshwari (Stanford),
 Richard Murray (Caltech),
 Milena Popovic (Blue Marble Space),
+Pasquale Stano (University of Salento),
 Kazhito Tabata (University of Tokyo),
 Paola Torre (University of Pennsylvania).
 
@@ -24,17 +25,17 @@ with an cell-free protein expression system.
 The preparation of liposomes using w/o emulsions as template requires
 four steps:
 
-### **Step 0**: Deposition of a thin lipid film in a glass vial
+### Step 0: Deposition of a thin lipid film in a glass vial
 
 #### Materials:
 
 * Glass vials (any will do, but we use [2mL Fisherbrand Class B Clear
   Glass Threaded vials: cat #:
-  03-339-21A](https://www.fishersci.com/shop/products/fisherbrand-class-b-clear-glass-threaded-vials-with-closures-packaged-separately-12/p-204738](https://www.fishersci.com/shop/products/fisherbrand-class-b-clear-glass-threaded-vials-with-closures-packaged-separately-12/p-204738)
+  03-339-21A](https://www.fishersci.com/shop/products/fisherbrand-class-b-clear-glass-threaded-vials-with-closures-packaged-separately-12/p-204738)
 
 * POPC in chloroform: [https://avantilipids.com/product/850457](https://avantilipids.com/product/850457) 
 
-* Lyss-Rhod-PE:
+* Liss-Rhod-PE:
   [https://avantilipids.com/product/810150](https://avantilipids.com/product/810150)
 
 * Cholesterol in chloroform (25 mg/ml): https://avantilipids.com/product/700000
@@ -44,13 +45,13 @@ four steps:
   for use with lipids and chloroform
   [https://www.hamiltoncompany.com/products/syringes-and-needles/general-syringes/gastight-syringes](https://www.hamiltoncompany.com/products/syringes-and-needles/general-syringes/gastight-syringes)
 
-### **Step 1**: Preparation of the oil containing lipids
+### Step 1: Preparation of the oil containing lipids
 
 #### Materials:
 
 * Mineral oil: [https://us.vwr.com/store/product/7422728/mineral-oil-light-white-high-purity-grade](https://us.vwr.com/store/product/7422728/mineral-oil-light-white-high-purity-grade)
 
-### **Step 2**: Self-assembly of the Liposomes by centrifugation
+### Step 2: Self-assembly of the Liposomes by centrifugation
 
 #### Materials:
 
@@ -58,13 +59,11 @@ four steps:
 
 * 100 mM HEPES, 200 mM glucose pH 8
 
-* 2M Sucrose Stock
-
 * 100 mM HEPES + 250 mM glucose, pH 8
 
 * 100 mM HEPES, 200 mM sucrose pH 8
 
-### **Step 3**: Microscopy Visualization
+### Step 3: Microscopy Visualization
 
 #### Materials:
 
@@ -79,25 +78,25 @@ to to form the lipid-in-mineral oil solution. Makes 6 samples with
 accurate measurement. Each vial will have ~ 15 mg of lipid with 0.1
 mol % of 18:1 Lyss-Rho-PE.
 
-1. Create lipid master mix in a glass beaker 
+1. Create lipid master mix in a glass beaker.  One of two methods may be used:
 
-    a. POPC/Lyss-Rhod-PE 
+    * POPC/Lyss-Rhod-PE 
 
-        i. Add  4 mL (100 mg) of POPC in chloroform (25 mg/ml) 
+        a. Add  4 mL (100 mg) of POPC in chloroform (25 mg/ml) 
 
-        ii. Add 200 uL (0.2 mg) of Lyss-Rho-PE in chloroform (1 mg/mL) 
+        b. Add 200 uL (0.2 mg) of Lyss-Rho-PE in chloroform (1 mg/mL) 
 
-        iii. Swirl gently until all POPC is dissolved and color is homogeneous.
+        c. Swirl gently until all POPC is dissolved and color is homogeneous.
 
-    b. POPC/Cholesterol/Lyss-Rhod-PE 
+    * POPC/Cholesterol/Lyss-Rhod-PE 
 
-        i. Add 2.668 mL (66.7 mg) of POPC in chloroform (25 mg/ml) 
+        a. Add 2.668 mL (66.7 mg) of POPC in chloroform (25 mg/ml) 
 
-        ii. Add 1.332 mL (33.3 mg) of Cholesterol in chloroform (25 mg/ml) 
+        b. Add 1.332 mL (33.3 mg) of Cholesterol in chloroform (25 mg/ml) 
 
-        iii. Add 200 uL (0.2 mg) of Lyss-Rho-PE in chloroform (1 mg/mL) 
+        c. Add 200 uL (0.2 mg) of Lyss-Rho-PE in chloroform (1 mg/mL) 
 
-        iv. Swirl gently until all POPC is dissolved and color is homogeneous.
+        d. Swirl gently until all POPC is dissolved and color is homogeneous.
 
 2. Aliquot 700 uL of POPC/Cholesterol/Lyss-Rhod-PE Chloroform solution
 into 2 mL glass vials (6 vials total)
@@ -109,7 +108,7 @@ foil and allow to evacuate overnight in fume hood (~6-8 hours).
       particles from contaminating the POPC/Cholesterol/Lyss-Rhod-PE
       as it evaporates.
 
-4. Move vials to vacuum chamber and vacuum for an additional 2 hours..
+4. Move vials to vacuum chamber and vacuum for an additional 2 hours.
 
 5. Store in -20 degC.
 
@@ -136,11 +135,11 @@ foil and allow to evacuate overnight in fume hood (~6-8 hours).
 
 ## Step 2: Self-assembly of the Liposomes by centrifugation
 
-1. Place 225 μL of centrifuge buffer (100 mM HEPES + 200 mM glucose,
+1. Place 225 uL of centrifuge buffer (100 mM HEPES + 200 mM glucose,
    pH 8) into a labeled eppendorf tube.
 
-    a. **Note**: When IVTL systems are used, the outer solution should
-    also contain the small molecular weight components of the IVTL
+    a. **Note**: When TX-TL systems are used, the outer solution should
+    also contain the small molecular weight components of the TX-TL
     system.
 
 2. Add in 30 uL of inner solution (100 mM HEPES, 200 mM sucrose pH 8,
@@ -148,10 +147,10 @@ foil and allow to evacuate overnight in fume hood (~6-8 hours).
    or calcein.) to 500 uL of suspended lipid in oil from Step
    1. Vortex for 30 s. Equilibrate for 10 min at 4 degC.
 
-    * **Note**: When IVTL systems are used, buffer is omitted. IVTLs
-    come with their own buffers.
+    * **Note**: When TX-TL systems are used, buffer is omitted. TX-TL
+    systems come with their own buffers.
 
-3. Add the emulsion on top of the 225 μL centrifuge buffer by
+3. Add the emulsion on top of the 225 uL centrifuge buffer by
 pipetting against the wall of the tube, wait at least 1 minute for the
 interface to stabilize and flatten between the emulsion and buffer
 
@@ -166,7 +165,7 @@ interface to stabilize and flatten between the emulsion and buffer
     * **Note: **The goal is to remove as much oil up to the interface
     without disturbing the buffer below.
 
-6. Place 225 μL of wash buffer (100 mM HEPES + 250 mM glucose, pH 8)
+6. Place 225 uL of wash buffer (100 mM HEPES + 250 mM glucose, pH 8)
    into a labeled eppendorf tube.
 
 7. Add the centrifuge buffer (where the vesicles should have formed)
@@ -180,21 +179,15 @@ interface to stabilize and flatten between the emulsion and buffer
 
 8. Centrifuge at 12000 rcf at 4 degC  for 5 min
 
-9. Transfer 225uL from the bottom of the eppendorf tubes with wash
+9. Transfer 225 uL from the bottom of the eppendorf tubes with wash
    buffer into a new labeled eppendorf tube.
-
-10. Add 10 μL of solution to 10 μL of final buffer (50 mM HEPES + 300
-    mM glucose, pH 8), careful not to touch the sides of tube If the
-    bottom buffer is already HEPES, then there is no need for buffer
-    change.  Is there an obvious reason to not directly go into the
-    desired buffer?
 
 ## Step 3: Microscopy Visualization
 
 1. Use Frameseal or Spacer (20 mm D x 0.12 mm depth) to make a small
    chamber on a microscope slide.
 
-2. Add 10 μL of the final solution to the chamber and seal with cover slip
+2. Add 10 uL of the final solution to the chamber and seal with cover slip
 
 3. Wait 5 minutes before imaging (since the liposomes will float
    everywhere and can be tricky to catch them).


### PR DESCRIPTION
This is the initial protocol for the water-in-oil method of creating liposomes, copies over from the [Google Doc file](https://docs.google.com/document/d/1FFXB5QqyxAkKPi0dNAS3onwyoqEnoEFxzCw2YCfv1LE).

This version has the following changes from the version on Google Docs:
* A version number, date, and list of contributors has been added to the top of the file
* Some reformatting of the text to make things look (more or less) right in MarkDown.

There are still some issues that need to be addressed, but those can be done through code review and adding issues.